### PR TITLE
Update neoforge repository url

### DIFF
--- a/src/resolver/neoforge/NeoForge.resolver.ts
+++ b/src/resolver/neoforge/NeoForge.resolver.ts
@@ -28,7 +28,7 @@ export class NeoForgeResolver extends BaseResolver {
     private static readonly logger = LoggerUtil.getLogger('NeoForgeResolver')
     private static readonly WILDCARD_NEOFORM_VERSION = '${formVersion}'
 
-    protected readonly REMOTE_REPOSITORY = 'https://maven.neoforged.net/'
+    protected readonly REMOTE_REPOSITORY = 'https://maven.neoforged.net/releases/'
 
     protected repoStructure: RepoStructure
     private generatedFiles: GeneratedFile[] | undefined


### PR DESCRIPTION
## Description

NeoForge updated their maven urls.

e.g. this url does not work anymore - https://maven.neoforged.net/net/neoforged/neoforge/21.1.219/neoforge-21.1.219-installer.jar

But this one does - https://maven.neoforged.net/releases/net/neoforged/neoforge/21.1.219/neoforge-21.1.219-installer.jar

Generating server now results in error:
```
npm run start -- generate server test 1.21.1 --neoforge 21.1.219
```

```
[2026-03-25 14:31:48] [debug] [NeoForgeResolver]: NeoForge installer not found locally, initializing download..
[2026-03-25 14:31:48] [debug] [BaseMavenRepo]: Downloading https://maven.neoforged.net/net/neoforged/neoforge/21.1.219/neoforge-21.1.219-installer.jar..
node:events:502
      throw er; // Unhandled 'error' event
      ^

HTTPError: Response code 404 (Not Found)
```

## Fix

This PR updates the `REMOTE_REPOSITORY` constant to fix this.

```
npm run start -- generate server test 1.21.1 --neoforge 21.1.219
```

```
...
[2026-03-25 16:09:47] [debug] [NeoForgeResolver]: NeoForge installer not found locally, initializing download..
[2026-03-25 16:09:47] [debug] [BaseMavenRepo]: Downloading https://maven.neoforged.net/releases/net/neoforged/neoforge/21.1.219/neoforge-21.1.219-installer.jar..
[2026-03-25 16:09:50] [debug] [BaseMavenRepo]: Completed download of https://maven.neoforged.net/releases/net/neoforged/neoforge/21.1.219/neoforge-21.1.219-installer.jar.
[2026-03-25 16:09:50] [debug] [NeoForgeResolver]: Beginning processing of NeoForge v21.1.219 (Minecraft 1.21.1)
[2026-03-25 16:09:50] [debug] [NeoForgeResolver]: Starting NeoForge installer.
...
```

